### PR TITLE
Improved: condition to make the value of partial allocation updated on server when selecting promise date and also enabled partial group allocation when partial allocation is enabled(#257)

### DIFF
--- a/src/views/BrokeringQuery.vue
+++ b/src/views/BrokeringQuery.vue
@@ -177,11 +177,11 @@
                 <ion-item>
                   <ion-icon slot="start" :icon="filterOutline"/>
                   <h4>{{ translate("Filters") }}</h4>
-                  <ion-button v-if="inventoryRuleFilterOptions && Object.keys(inventoryRuleFilterOptions).length" slot="end" fill="clear" @click="addInventoryFilterOptions('INV_FILTER_PRM_TYPE', 'ENTCT_FILTER', 'Filters')">
+                  <ion-button v-if="isInventoryRuleFiltersApplied()" slot="end" fill="clear" @click="addInventoryFilterOptions('INV_FILTER_PRM_TYPE', 'ENTCT_FILTER', 'Filters')">
                     <ion-icon slot="icon-only" :icon="optionsOutline"/>
                   </ion-button>
                 </ion-item>
-                <p class="empty-state" v-if="!inventoryRuleFilterOptions || !Object.keys(inventoryRuleFilterOptions).length">
+                <p class="empty-state" v-if="!isInventoryRuleFiltersApplied()">
                   {{ translate("All facilities enabled for online fulfillment will be attempted for brokering if no filter is applied.") }}<br /><br />
                   <span><a target="_blank" rel="noopener noreferrer" href="https://docs.hotwax.co/documents/v/system-admins/administration/facilities/configure-fulfillment-capacity">{{ translate("Learn more") }}</a>{{ translate(" about enabling a facility for online fulfillment.") }}</span>
                   <ion-button fill="clear" @click="addInventoryFilterOptions('INV_FILTER_PRM_TYPE', 'ENTCT_FILTER', 'Filters')">
@@ -815,6 +815,11 @@ function updatePartialAllocation(checked: any) {
     }
   })
   hasUnsavedChanges.value = true
+}
+
+function isInventoryRuleFiltersApplied() {
+  const ruleFilters = Object.keys(inventoryRuleFilterOptions.value).filter((rule: string) => rule !== conditionFilterEnums["SPLIT_ITEM_GROUP"].code);
+  return ruleFilters.length
 }
 
 function isPromiseDateFilterApplied() {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#257

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Added case to display empty state in the rule filter card, when partial group item allocation filter is selected

On selecting promise date, the partial allocation and partial allocation group items being enabled, but when removing promise date filter the allocation are not removed.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/order-routing-rules#contribution-guideline)