### PR TITLE
Fixed: modified logic of BrokeringRuns page to shows description of any custom cron expression set by user. (#293)

### DIFF
--- a/src/views/BrokeringRuns.vue
+++ b/src/views/BrokeringRuns.vue
@@ -50,7 +50,7 @@
               <ion-item v-if="group.schedule?.paused === 'N'">
                 <ion-label>
                   {{ group.schedule ? getDateAndTime(group.schedule.nextExecutionDateTime) : "-" }}
-                  <p>{{ group.schedule ? getScheduleFrequency(group.schedule.cronExpression) : "-" }}</p>
+                  <p>{{ group.schedule ? getScheduleFrequency(group.schedule) : "-" }}</p>
                 </ion-label>
                 <ion-badge slot="end" color="dark">
                   {{ group.schedule ? timeTillRun(group.schedule.nextExecutionDateTime) : "-" }}
@@ -175,8 +175,31 @@ async function setEComStore(event: CustomEvent) {
   emitter.emit("dismissLoader")
 }
 
-function getScheduleFrequency(cronExp: string) {
-  return Object.entries(cronExpressions).find(([description, expression]) => expression === cronExp)?.[0] || "-"
+function getScheduleFrequency(brokeringGroupObj: any) {
+  const foundDescription = Object.entries(cronExpressions).find(
+    ([description, expression]) => expression === brokeringGroupObj.cronExpression
+  )?.[0];
+
+  if (foundDescription) {
+    return foundDescription;
+  }
+
+  if (brokeringGroupObj.cronDescription) {
+    const executionTimeZone = brokeringGroupObj.executionTimeZone || "";
+    let processedDescription = brokeringGroupObj.cronDescription
+      .replace(executionTimeZone, "")
+      .replace("time", "")
+      .trim();
+
+    // Capitalize the first letter if it's not a number or symbol
+    if (/^[a-z]/.test(processedDescription)) {
+      processedDescription = processedDescription.charAt(0).toUpperCase() + processedDescription.slice(1);
+    }
+
+    return processedDescription;
+  }
+
+  return "-";
 }
 
 async function redirect(group: Group) {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->
#293 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
The getScheduleFrequency function now determines the schedule frequency description for a brokering group. 
It first checks if the cronExpression matches any predefined descriptions in the cronExpressions object and returns the corresponding description if found in .env . If no match is found, it processes the cronDescription by removing the executionTimeZone and the word "time," then capitalizes the first letter if it starts with a lowercase letter (and is not a number or symbol). If neither is available, it defaults to returning "-".

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
[Screencast from 16-04-25 11:04:02 AM IST.webm](https://github.com/user-attachments/assets/8834d477-f92a-444a-be08-73ee5ae898aa)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/order-routing-rules#contribution-guideline)