### PR TITLE
Fixed: issue in brokering safety stock filter to have greater as its default operator

### DIFF
--- a/src/views/BrokeringQuery.vue
+++ b/src/views/BrokeringQuery.vue
@@ -316,7 +316,7 @@
                             <ion-select-option value="greater">{{ translate("greater") }}</ion-select-option>
                           </ion-select>
                         </ion-chip>
-                        <ion-chip outline @click="selectValue('BRK_SAFETY_STOCK', 'Add safety stock')">{{ getFilterValue(inventoryRuleFilterOptions, conditionFilterEnums, "BRK_SAFETY_STOCK").fieldValue || getFilterValue(inventoryRuleFilterOptions, conditionFilterEnums, "BRK_SAFETY_STOCK").fieldValue == 0 ? getFilterValue(inventoryRuleFilterOptions, conditionFilterEnums, "BRK_SAFETY_STOCK").fieldValue : "-" }}</ion-chip>
+                        <ion-chip outline @click="selectValue('BRK_SAFETY_STOCK', 'Add safety stock', 'greater')">{{ getFilterValue(inventoryRuleFilterOptions, conditionFilterEnums, "BRK_SAFETY_STOCK").fieldValue || getFilterValue(inventoryRuleFilterOptions, conditionFilterEnums, "BRK_SAFETY_STOCK").fieldValue == 0 ? getFilterValue(inventoryRuleFilterOptions, conditionFilterEnums, "BRK_SAFETY_STOCK").fieldValue : "-" }}</ion-chip>
                       </div>
                     </ion-item>
 
@@ -1095,7 +1095,7 @@ async function selectPromiseFilterValue(ev: CustomEvent, type = "included") {
   return popover.present();
 }
 
-async function selectValue(id: string, header: string) {
+async function selectValue(id: string, header: string, operator = "equals") {
   const filter = getFilterValue(inventoryRuleFilterOptions.value, conditionFilterEnums, id)
   const valueAlert = await alertController.create({
     header,
@@ -1119,7 +1119,7 @@ async function selectValue(id: string, header: string) {
       filter.fieldValue = value
       // When selecting a filter value making the operator to default `equals` if not present already
       // For proximity filter we need to have less-equals as operator
-      filter.operator = (id === "PROXIMITY" ? "less-equals" : filter.operator || "equals")
+      filter.operator = (id === "PROXIMITY" ? "less-equals" : filter.operator || operator)
       updateRule()
     }
   })


### PR DESCRIPTION
When selecting brokering safety stock without selecting an operator, the default value passed in was equals, so fixed code to make the operator default value as greater in case of brokering safety stock filter

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/order-routing-rules#contribution-guideline)