### PR TITLE
Updated Learn More link in RuleDetails.vue to Configure Online Fulfillment page

### DIFF
--- a/src/components/RuleDetails.vue
+++ b/src/components/RuleDetails.vue
@@ -35,7 +35,7 @@
             </ion-item>
             <p class="empty-state" v-if="!isInventoryRuleFiltersApplied()">
               {{ translate("All facilities enabled for online fulfillment will be attempted for brokering if no filter is applied.") }}<br /><br />
-              <span><a target="_blank" rel="noopener noreferrer" href="https://docs.hotwax.co/documents/v/system-admins/administration/facilities/configure-fulfillment-capacity">{{ translate("Learn more") }}</a>{{ translate(" about enabling a facility for online fulfillment.") }}</span>
+              <span><a target="_blank" rel="noopener noreferrer" href="https://docs.hotwax.co/documents/v/system-admins/administration/facilities/configure-fulfillment">{{ translate("Learn more") }}</a>{{ translate(" about enabling a facility for online fulfillment.") }}</span>
             </p>
             <ion-item v-if="getFilterValue(inventoryRuleFilterOptions, conditionFilterEnums, 'FACILITY_GROUP')">
               <ion-label>{{ translate("Group") }}</ion-label>


### PR DESCRIPTION
Redirect the link from the Configure Fulfillment Capacity page to the Configure Online Fulfillment page.

### Related Issues
issue #306 